### PR TITLE
Bump dependency versions and adds .net8.0 support

### DIFF
--- a/example/JustAnotherService/JustAnotherService.csproj
+++ b/example/JustAnotherService/JustAnotherService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/example/JustAnotherService/JustAnotherService.csproj
+++ b/example/JustAnotherService/JustAnotherService.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
     </ItemGroup>
 
 </Project>

--- a/example/User.Api/Extension/ApiDependencyExtensions.cs
+++ b/example/User.Api/Extension/ApiDependencyExtensions.cs
@@ -13,7 +13,7 @@ namespace User.Api.Extension
         {
             return services
                 .AddHttpContextAccessor()
-                .AddMediatR(typeof(Startup))
+                .AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Startup).Assembly))
                 .AddScoped<IJustAnotherServiceProvider, JustAnotherServiceProvider>();
         }
     }

--- a/example/User.Api/User.Api.csproj
+++ b/example/User.Api/User.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>User.Api</AssemblyName>
         <RootNamespace>User.Api</RootNamespace>
     </PropertyGroup>

--- a/example/User.Api/User.Api.csproj
+++ b/example/User.Api/User.Api.csproj
@@ -6,19 +6,24 @@
         <RootNamespace>User.Api</RootNamespace>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="MediatR" Version="9.0.0" />
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.13" />
+        <PackageReference Include="MediatR" Version="12.4.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
         <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.3" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.7.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 </Project>

--- a/example/User.ComponentTests/User.ComponentTests.csproj
+++ b/example/User.ComponentTests/User.ComponentTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/example/User.ComponentTests/User.ComponentTests.csproj
+++ b/example/User.ComponentTests/User.ComponentTests.csproj
@@ -8,15 +8,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
+        <PackageReference Include="xunit" Version="2.9.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-        <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
-        <PackageReference Include="coverlet.collector" Version="3.0.2">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="xunit.extensibility.core" Version="2.9.0" />
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/example/User.IntegrationTests/User.IntegrationTests.csproj
+++ b/example/User.IntegrationTests/User.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/example/User.IntegrationTests/User.IntegrationTests.csproj
+++ b/example/User.IntegrationTests/User.IntegrationTests.csproj
@@ -8,13 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="xunit" Version="2.9.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/ConfIT/ConfIT.csproj
+++ b/src/ConfIT/ConfIT.csproj
@@ -1,17 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net7.0;net6.0;net5.0</TargetFrameworks>
     </PropertyGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.8" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.20" />
+    </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.33" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.13" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.17" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.1.0" />
+        <PackageReference Include="FluentAssertions" Version="6.12.1" />
         <PackageReference Include="JsonDiffPatch.Net" Version="2.3.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="WireMock.Net" Version="1.4.32" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="WireMock.Net" Version="1.6.3" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
### **User description**
It turns out that if you use ConfIT with .net8.0 libraries there are some dependencies clashes.
Namely, `Microsoft.EntityFrameworkCore.InMemory`, 8.0.8 requires `Humanizer.Core` at least 2.14.1, but internally, I believe the old Wiremock version still uses 2.11.10.
While the error can be solved by explicitly adding a direct reference to the latest Humanizer.Core, with `<PackageReference Include="Humanizer.Core" Version="2.14.1" />` to the .csproj, it screams warnings all over the place.

This PR was my best effort to update the dependencies while maintaining compatibility with previous .net versions.
The example projects were also bumped to .net8.0 and all other libraries in the example to latest.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added .NET 8.0 support across multiple projects.

- Updated dependencies to resolve compatibility issues and warnings.

- Improved dependency registration for MediatR in `User.Api`.

- Enhanced compatibility by targeting multiple .NET versions in `ConfIT`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ApiDependencyExtensions.cs</strong><dd><code>Improved MediatR dependency registration in `User.Api`.</code>&nbsp; &nbsp; </dd></summary>
<hr>

example/User.Api/Extension/ApiDependencyExtensions.cs

<li>Updated MediatR dependency registration to use <br><code>RegisterServicesFromAssembly</code>.


</details>


  </td>
  <td><a href="https://github.com/techygarg/ConfIT/pull/4/files#diff-ff8d1d9179958cd31f7188567b7d93a0760f9900e7a0152766ed890656b88c83">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>JustAnotherService.csproj</strong><dd><code>Upgraded framework and dependencies in `JustAnotherService`.</code></dd></summary>
<hr>

example/JustAnotherService/JustAnotherService.csproj

<li>Upgraded target framework to .NET 8.0.<br> <li> Updated <code>Swashbuckle.AspNetCore</code> dependency to version 6.7.3.


</details>


  </td>
  <td><a href="https://github.com/techygarg/ConfIT/pull/4/files#diff-eb7cd8bec862672e159f0f8295a07802e492a45a6ec16098b470afaf88b23dbf">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>User.Api.csproj</strong><dd><code>Upgraded framework and dependencies in `User.Api`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example/User.Api/User.Api.csproj

<li>Upgraded target framework to .NET 8.0.<br> <li> Updated multiple dependencies to latest versions.<br> <li> Added <code>PrivateAssets</code> and <code>IncludeAssets</code> for EF Core tools.


</details>


  </td>
  <td><a href="https://github.com/techygarg/ConfIT/pull/4/files#diff-905cd1051969f7715e40cbf8e47572956993d73901211eab58c7e0c61fb06c24">+17/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>User.ComponentTests.csproj</strong><dd><code>Upgraded framework and testing dependencies in `User.ComponentTests`.</code></dd></summary>
<hr>

example/User.ComponentTests/User.ComponentTests.csproj

<li>Upgraded target framework to .NET 8.0.<br> <li> Updated testing dependencies to latest versions.


</details>


  </td>
  <td><a href="https://github.com/techygarg/ConfIT/pull/4/files#diff-08392fd0150e901fd7f715557512b6f9f625fe9df3e93bd1e9fdd46b15226dd0">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>User.IntegrationTests.csproj</strong><dd><code>Upgraded framework and testing dependencies in <code>User.IntegrationTests</code>.</code></dd></summary>
<hr>

example/User.IntegrationTests/User.IntegrationTests.csproj

<li>Upgraded target framework to .NET 8.0.<br> <li> Updated testing dependencies to latest versions.


</details>


  </td>
  <td><a href="https://github.com/techygarg/ConfIT/pull/4/files#diff-3616c1b5d236ba9da2fb8dd03193f5f0346834233a2b58d91c82dbfba6494296">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ConfIT.csproj</strong><dd><code>Enhanced multi-framework support and updated dependencies in <code>ConfIT</code>.</code></dd></summary>
<hr>

src/ConfIT/ConfIT.csproj

<li>Added support for .NET 8.0 and .NET 7.0.<br> <li> Updated <code>Microsoft.AspNetCore.TestHost</code> for each target framework.<br> <li> Updated <code>FluentAssertions</code>, <code>Newtonsoft.Json</code>, and <code>WireMock.Net</code> <br>dependencies.


</details>


  </td>
  <td><a href="https://github.com/techygarg/ConfIT/pull/4/files#diff-90c3f712852b2ea98c52e7dabd6092f54547049ecfa9bf6b79dbc21b9bcc21cd">+12/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>