### PR TITLE
Enable BodyFromFile for mock interactions

### DIFF
--- a/src/ConfIT/Server/Dto/ApiInteraction.cs
+++ b/src/ConfIT/Server/Dto/ApiInteraction.cs
@@ -1,11 +1,11 @@
 namespace ConfIT.Server.Dto
 {
-    public class TestApi
+    public abstract class ApiInteraction
     {
         public HttpTestRequest Request { get; set; }
         public HttpTestResponse Response { get; set; }
 
-        public TestApi Initialize(string requestFolder, string responseFolder)
+        public ApiInteraction Initialize(string requestFolder, string responseFolder)
         {
             Request.Initialize(requestFolder);
             Response.Initialize(responseFolder);

--- a/src/ConfIT/Server/Dto/TestCase.cs
+++ b/src/ConfIT/Server/Dto/TestCase.cs
@@ -5,24 +5,23 @@ namespace ConfIT.Server.Dto
     public class TestCase
     {
         public List<string> Tags { get; set; }
-        public TestMock Mock { get; set; }
+        public TestMock? Mock { get; set; }
         public TestApi Api { get; set; }
 
         public TestCase Initialize(string requestFolder, string responseFolder)
         {
             Api.Initialize(requestFolder, responseFolder);
+            Mock?.Interactions.ForEach(interaction => interaction.Initialize(requestFolder, responseFolder));
             return this;
         }
     }
 
     public class TestMock
     {
-        public List<MockInteraction> Interactions { get; set; }
+        public List<MockInteraction> Interactions { get; set; } = new();
     }
 
-    public class MockInteraction
-    {
-        public HttpTestRequest Request { get; set; }
-        public HttpTestResponse Response { get; set; }
-    }
+    public class MockInteraction : ApiInteraction { }
+    
+    public class TestApi : ApiInteraction { }
 }


### PR DESCRIPTION
This adds the possibility to use BodyFromFile also in mocked interactions, cleaning up testcase files when mock interaction have lagers bodies.