### PR TITLE
fix: NullReferenceException in SemanticMatcher + HttpClient leak in BootstrappedSuite

### DIFF
--- a/src/ConfIT/BootstrappedSuite.cs
+++ b/src/ConfIT/BootstrappedSuite.cs
@@ -1,4 +1,5 @@
 using ConfIT.Reporting;
+using ConfIT.Runner.Http;
 
 namespace ConfIT;
 
@@ -12,6 +13,7 @@ public sealed class BootstrappedSuite : IDisposable
 {
     private readonly IDisposable?        _infrastructure;
     private readonly TestResultCollector _resultCollector;
+    private readonly TestHttpClient?     _ownedHttpClient;
     private bool                         _disposed;
 
     /// <summary>
@@ -27,15 +29,17 @@ public sealed class BootstrappedSuite : IDisposable
     public IServiceProvider? Services { get; }
 
     internal BootstrappedSuite(
-        TestSuiteContext  context,
-        IDisposable?      infrastructure,
+        TestSuiteContext    context,
+        IDisposable?        infrastructure,
         TestResultCollector resultCollector,
-        IServiceProvider? services = null)
+        IServiceProvider?   services        = null,
+        TestHttpClient?     ownedHttpClient = null)
     {
         Context          = context;
         _infrastructure  = infrastructure;
         _resultCollector = resultCollector;
         Services         = services;
+        _ownedHttpClient = ownedHttpClient;
     }
 
     public void Dispose()
@@ -46,5 +50,6 @@ public sealed class BootstrappedSuite : IDisposable
         // Print the suite summary before tearing down infrastructure.
         _resultCollector.Dispose();
         _infrastructure?.Dispose();
+        _ownedHttpClient?.Dispose();
     }
 }

--- a/src/ConfIT/Matching/ResultMatcher.cs
+++ b/src/ConfIT/Matching/ResultMatcher.cs
@@ -13,7 +13,7 @@ public static class ResultMatcher
         IReadOnlyDictionary<string, SemanticMatcherFunc>? customMatchers = null)
     {
         var actual          = actualResponse.DeepClone();
-        var semanticFailure = SemanticMatcher.Apply(actual, expectedResponse!, matcher?.Semantic, customMatchers);
+        var semanticFailure = SemanticMatcher.Apply(actual, expectedResponse, matcher?.Semantic, customMatchers);
         if (semanticFailure is not null)
             return new MatchResult(false, semanticFailure);
 

--- a/src/ConfIT/Matching/SemanticMatcher.cs
+++ b/src/ConfIT/Matching/SemanticMatcher.cs
@@ -46,7 +46,7 @@ public static class SemanticMatcher
     // Mutates actual and expected by removing matched fields (so the diff step skips them).
     public static string? Apply(
         JToken actual,
-        JToken expected,
+        JToken? expected,
         Dictionary<string, string>? semantic,
         IReadOnlyDictionary<string, SemanticMatcherFunc>? customMatchers)
     {
@@ -71,7 +71,8 @@ public static class SemanticMatcher
                 return $"field '{fieldPath}' [{matcherSpec}]: {failure}";
 
             actualField.Parent?.Remove();
-            expected.SelectToken(jPath)?.Parent?.Remove();
+            // expected may be null when a test defines semantic matchers but omits response.body
+            expected?.SelectToken(jPath)?.Parent?.Remove();
         }
 
         return null;

--- a/src/ConfIT/SuiteBootstrapper.cs
+++ b/src/ConfIT/SuiteBootstrapper.cs
@@ -80,7 +80,7 @@ public static class SuiteBootstrapper
             Filter:          cfg.ToTestFilter(),
             ResultCollector: resultCollector);
 
-        return new BootstrappedSuite(context, launcher, resultCollector);
+        return new BootstrappedSuite(context, launcher, resultCollector, ownedHttpClient: httpClient);
     }
 
     /// <summary>
@@ -110,7 +110,7 @@ public static class SuiteBootstrapper
             Filter:          cfg.ToTestFilter(),
             ResultCollector: resultCollector);
 
-        return new BootstrappedSuite(context, infrastructure: null, resultCollector);
+        return new BootstrappedSuite(context, infrastructure: null, resultCollector, ownedHttpClient: httpClient);
     }
 
     // Resolves the response folder to an absolute path and ensures it exists.

--- a/test/ConfIT.UnitTest/Util/ResultMatcherTests.cs
+++ b/test/ConfIT.UnitTest/Util/ResultMatcherTests.cs
@@ -168,6 +168,18 @@ public class ResultMatcherTests
     }
 
     [Fact]
+    public void MatchResponseBody_NullExpectedWithSemanticMatcher_DoesNotThrow()
+    {
+        // Given — response.body omitted in test definition but semantic matcher declared
+        var actual  = JToken.Parse("{'id': 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'}");
+        var matcher = new Matcher { Semantic = new Dictionary<string, string> { ["id"] = "isUuid" } };
+
+        // When / Then — must not throw NullReferenceException
+        var act = () => ResultMatcher.MatchResponseBody(actual, null, matcher);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
     public void MatchResponseBody_InvalidRegexPattern_ThrowsArgumentException()
     {
         // Given

--- a/test/ConfIT.UnitTest/Util/SemanticMatcherTests.cs
+++ b/test/ConfIT.UnitTest/Util/SemanticMatcherTests.cs
@@ -267,6 +267,19 @@ public class SemanticMatcherTests
         action.Should().Throw<InvalidOperationException>().WithMessage("*id*absent*");
     }
 
+    [Fact]
+    public void Apply_NullExpected_DoesNotThrow()
+    {
+        // When response.body is omitted in the test definition but semantic matchers are declared,
+        // expected is null. Actual-field validation still runs; removal from expected is skipped.
+        var result = SemanticMatcher.Apply(
+            JToken.Parse("{'id': 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'}"),
+            null,
+            new Dictionary<string, string> { ["id"] = "isUuid" },
+            null);
+        result.Should().BeNull();
+    }
+
     #endregion
 
     #region Custom matcher extension


### PR DESCRIPTION
## Summary

Two bugs identified in the PR #9 review, fixed with regression tests.

### Bug 1 — `SemanticMatcher.Apply` NullReferenceException

`ResultMatcher.MatchResponseBody` accepts a nullable `expectedResponse` (a test may omit `response.body`) but was forwarding it with a `!` null-forgiving operator into `SemanticMatcher.Apply`, which unconditionally called `expected.SelectToken(...)` — crashing at runtime when a test defines semantic matchers but no expected body.

**Fix:**
- `SemanticMatcher.Apply` parameter: `JToken expected` → `JToken? expected`
- `expected.SelectToken(...)` → `expected?.SelectToken(...)` — skips the expected-field removal when null; actual-field validation still runs
- `ResultMatcher`: removed the `!` operator that was masking the issue

### Bug 2 — `TestHttpClient` not disposed in `ForCommand` / `ForIntegration`

`SuiteBootstrapper.ForCommand` and `ForIntegration` create a `TestHttpClient` via `TestHttpClient.Create(...)` (which wraps a new `HttpClient`). `BootstrappedSuite.Dispose()` was only disposing `_infrastructure` and `_resultCollector`, leaving the `HttpClient` and its socket handlers leaked.

`ForComponent` was unaffected — `TestSuiteInitializer` owns and disposes its client when `_infrastructure.Dispose()` is called.

**Fix:**
- `BootstrappedSuite` gains an `_ownedHttpClient` field (null for `ForComponent`)
- `Dispose()` calls `_ownedHttpClient?.Dispose()` after infrastructure teardown
- `SuiteBootstrapper.ForCommand` and `ForIntegration` pass `ownedHttpClient: httpClient`

## Test plan

- [x] `Apply_NullExpected_DoesNotThrow` — `SemanticMatcher.Apply` with null expected does not throw
- [x] `MatchResponseBody_NullExpectedWithSemanticMatcher_DoesNotThrow` — end-to-end via `ResultMatcher`
- [x] `make unit` — 248 passing (net9.0 + net10.0)

